### PR TITLE
find mpi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,12 @@ if (Kokkos_HAS_CUDA AND (NOT Kokkos_HAS_CUDA_LAMBDA))
 endif()
 
 bob_option(Omega_h_USE_MPI "Use MPI for parallelism" OFF)
+if(Omega_h_USE_MPI)
+  set(MPI_CXX_SKIP_MPICXX ON) #don't need MPI C++ bindings
+  bob_add_dependency(PUBLIC NAME MPI
+    INCLUDE_DIR_VARS MPI_CXX_INCLUDE_DIRS
+    LIBRARY_VARS MPI_CXX_LIBRARIES)
+endif()
 bob_option(Omega_h_USE_OpenMP "Whether to use OpenMP" "${Kokkos_HAS_OpenMP}")
 bob_option(Omega_h_USE_CUDA "Whether to use CUDA" "${Kokkos_HAS_CUDA}")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -229,6 +229,8 @@ bob_link_dependency(omega_h PUBLIC SEACASExodus)
 
 bob_link_dependency(omega_h PUBLIC ZLIB)
 
+bob_link_dependency(omega_h PUBLIC MPI)
+
 if (Omega_h_USE_dwarf)
   target_include_directories(omega_h PRIVATE "${LIBDWARF_INCLUDE_DIRS}")
   target_link_libraries(omega_h PUBLIC "${LIBDWARF_LIBRARIES}")


### PR DESCRIPTION
This PR treats the MPI libraries as a dependency instead of relying on the compiler wrappers.  This has been tested successfully (configuring with `-DBUILD_TESTING=ON` and then running `ctest`) with:
- GCC 7.4 + MPICH 3.1 with and without CUDA enabled,
- GCC 10.1.0 + OpenMPI 3.1 with and without CUDA enabled, and
- GCC 10.1.0 with MPI disabled and CUDA enabled.