### PR TITLE
require mpi >3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ endif()
 
 if (Omega_h_USE_MPI)
   enable_language(C)
-  find_package(MPI REQUIRED)
+  find_package(MPI 3 REQUIRED)
 endif()
 
 set(Omega_h_USE_ZLIB_DEFAULT ON)


### PR DESCRIPTION
MPI_Neighbor_alltoallv and MPI_Ibarrier are from MPI 3

The xSDK Version 0.6.0 package policy M3 requires the MPI version check.  http://dx.doi.org/10.6084/m9.figshare.4495136

The updated xSDK policy doc is here: https://github.com/xsdk-project/xsdk-policy-compatibility/pull/48