### PR TITLE
support make check

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -563,9 +563,11 @@ endif()
 
 #define 'smoke tests' to test the install
 add_custom_target(test_install DEPENDS check) # maintain test_install target
-add_custom_target(check
-  COMMAND ${CMAKE_CTEST_COMMAND} -L SMOKE_TEST
-  COMMENT "Test installed Omega_h utilities")
+if(NOT BUILD_TESTING)
+  add_custom_target(check
+    COMMAND ${CMAKE_CTEST_COMMAND} -L SMOKE_TEST
+    COMMENT "Test installed Omega_h utilities")
+endif()
 
 function(smoke_test EXE DEP)
   set(prefix "smoke_test")


### PR DESCRIPTION
This PR adds Spack support for running the tests defined under the `test_install` target as build/install time tests.  When a Spack user runs `spack install --test` Spack will call `make check`.   

Build/install time testing support is needed for ECP CI testing: https://confluence.exascaleproject.org/display/HISD/SI+Build+and+Test+Dashboard (requires login).

Adding cmake [fixtures](https://crascit.com/2016/10/18/test-fixtures-with-cmake-ctest/) to specify the ordering of tests, and the label to group them, are not strictly required but I think make the solution cleaner.