### PR TITLE
Fix regression where bob was not called anymore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,9 @@ if (Omega_h_USE_CUDA)
   enable_language(CUDA)
 endif()
 
+bob_begin_cxx_flags()
+bob_cxx11_flags()
+
 include(cmake/osh_use_dolfin.cmake)
 osh_use_dolfin()
 


### PR DESCRIPTION
Since 976a34043a88858de1dd8a6d4e5b5c6d654ac9fd CMake options like `Omega_h_CXX_OPTIMIZE`
are not taken into account (not compiled with `-O3`), which explain the huge performance
degradation we observed in v9.30.0.