### PR TITLE
libmeshb: pass a const string

### DIFF
--- a/src/Omega_h_file.cpp
+++ b/src/Omega_h_file.cpp
@@ -648,7 +648,7 @@ OMEGA_H_DLL Mesh read_mesh_file(filesystem::path const& path, CommPtr comm) {
   } else if (extension == ".meshb") {
 #ifdef OMEGA_H_USE_LIBMESHB
     Mesh mesh(comm->library());
-    meshb::read(&mesh, path);
+    meshb::read(&mesh, path.c_str());
     mesh.set_comm(comm);
     return mesh;
 #else

--- a/src/osh_adapt.cpp
+++ b/src/osh_adapt.cpp
@@ -63,7 +63,7 @@ int main(int argc, char** argv) {
   } else
 #ifdef OMEGA_H_USE_LIBMESHB
       if (metric_in_ext == ".sol" || metric_in_ext == ".solb") {
-    Omega_h::meshb::read_sol(&mesh, metric_in, "target_metric");
+    Omega_h::meshb::read_sol(&mesh, metric_in.c_str(), "target_metric");
     target_metric = mesh.get_array<Omega_h::Real>(0, "target_metric");
   } else
 #endif
@@ -86,7 +86,7 @@ int main(int argc, char** argv) {
     } else
 #ifdef OMEGA_H_USE_LIBMESHB
         if (metric_out_ext == ".sol" || metric_out_ext == ".solb") {
-      Omega_h::meshb::write_sol(&mesh, metric_out, "metric");
+      Omega_h::meshb::write_sol(&mesh, metric_out.c_str(), "metric");
     } else
 #endif
     {


### PR DESCRIPTION
This PR fixes a few compilation errors when libMeshb (`OMEGA_H_USE_LIBMESHB`) is enabled.  

gcc 7.3.0 was reporting the following errors. I 'fixed' them by calling `c_str()` on the `filesystem::path` objects. It looks like `native()` may have also worked to satisfy the `const`.

```
[ 57%] Building CXX object src/CMakeFiles/osh_adapt.dir/osh_adapt.cpp.o
/space/cwsmith/pumi-omegah/omegah/src/osh_adapt.cpp: In function ‘int main(int, char**)’:
/space/cwsmith/pumi-omegah/omegah/src/osh_adapt.cpp:66:63: error: invalid initialization of reference of type ‘const string& {aka const std::__cxx11::basic_string<char>&}’ from expression of type ‘Omega_h::filesystem::path’
     Omega_h::meshb::read_sol(&mesh, metric_in, "target_metric");
                                                               ^
In file included from /space/cwsmith/pumi-omegah/omegah/src/osh_adapt.cpp:5:0:
/space/cwsmith/pumi-omegah/omegah/src/Omega_h_file.hpp:25:6: note: in passing argument 2 of ‘void Omega_h::meshb::read_sol(Omega_h::Mesh*, const string&, const string&)’
 void read_sol(
      ^~~~~~~~
/space/cwsmith/pumi-omegah/omegah/src/osh_adapt.cpp:89:60: error: invalid initialization of reference of type ‘const string& {aka const std::__cxx11::basic_string<char>&}’ from expression of type ‘Omega_h::filesystem::path’
       Omega_h::meshb::write_sol(&mesh, metric_out, "metric");
                                                            ^
In file included from /space/cwsmith/pumi-omegah/omegah/src/osh_adapt.cpp:5:0:
/space/cwsmith/pumi-omegah/omegah/src/Omega_h_file.hpp:27:6: note: in passing argument 2 of ‘void Omega_h::meshb::write_sol(Omega_h::Mesh*, const string&, const string&, int)’
 void write_sol(Mesh* mesh, std::string const& filepath,
      ^~~~~~~~~
make[2]: *** [src/CMakeFiles/osh_adapt.dir/osh_adapt.cpp.o] Error 1
make[1]: *** [src/CMakeFiles/osh_adapt.dir/all] Error 2
make: *** [all] Error 2
```