### PR TITLE
mpi: transitive dep for downstream packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,8 @@ endif()
 
 if (Omega_h_USE_MPI)
   enable_language(C)
-  find_package(MPI 3 REQUIRED)
+  set(MPI_REQUIRED_VERSION 3)
+  bob_add_dependency(PUBLIC NAME MPI TARGETS MPI::MPI_CXX)
 endif()
 
 set(Omega_h_USE_ZLIB_DEFAULT ON)


### PR DESCRIPTION
This PR uses `bob_add_dependency(...)` instead of the direct call to `find_package` so that MPI is included in Omega_h's list of transitive dependencies.