### PR TITLE
Fix windows build

### DIFF
--- a/src/unit_mesh.cpp
+++ b/src/unit_mesh.cpp
@@ -741,7 +741,7 @@ static void test_hypercube_split_template() {
   OMEGA_H_CHECK(compare_hst(3, 3, 7, 7, {0, 7}));
 }
 
-static void test_copy_constructor(Library* lib)
+void test_copy_constructor(Library* lib)
 {
   auto world = lib->world();
   fprintf(stderr, "before build_box\n");


### PR DESCRIPTION
Windows compile error using Visual Studio 2019 (MSVC 14.24.28314) and CUDA 11.7:

C:\Some\Path\To\Source\omega_h\src\unit_mesh.cpp(755): error : On Windows, the enclosing parent function ("test_copy_constructor") for an extended __device__ lambda cannot have internal or no linkage [C:\Some\Path\To\Build\omega_h\src\unit_mesh.vcxproj]