### PR TITLE
Use host device markup always

### DIFF
--- a/src/Omega_h_atomics.hpp
+++ b/src/Omega_h_atomics.hpp
@@ -27,7 +27,7 @@ OMEGA_H_DEVICE int atomic_fetch_add(int* const dest, const int val) {
 #pragma GCC diagnostic pop
 #endif
   return oldval;
-#elif defined(OMEGA_H_USE_CUDA)
+#elif defined(OMEGA_H_USE_CUDA) && defined(__CUDA_ARCH__)
   return atomicAdd(dest, val);
 #else
   int oldval = *dest;

--- a/src/Omega_h_macros.h
+++ b/src/Omega_h_macros.h
@@ -41,8 +41,8 @@
 #if defined(OMEGA_H_USE_CUDA)
 #define OMEGA_H_INLINE __host__ __device__ inline
 #define OMEGA_H_INLINE_BIG OMEGA_H_INLINE
-#define OMEGA_H_DEVICE __device__ inline
-#define OMEGA_H_LAMBDA [=] __device__
+#define OMEGA_H_DEVICE __host__ __device__ inline
+#define OMEGA_H_LAMBDA [=] __host__ __device__
 #define OMEGA_H_CONSTANT_DATA __constant__
 #elif defined(_MSC_VER)
 #define OMEGA_H_INLINE __forceinline


### PR DESCRIPTION
HI Dan,

we ran into some issues with a code which was using both omega_h and Kokkos. Specifically the issue is that we do analysis of functor signatures for reductions, but if the operator / lambda is __device__ only that will fail, since the analysis happens in a host context. Now we changed their lambda to __host__ __device__ but then it complained about calling __device__ functions from Omega (specifically [] operator of some class).

This is not a real proposal for you to merge, just demonstrating something which made problems go away. The Omega_h build itself seemed to only stumble over the atomicAdd when changing the macros.  