### PR TITLE
added block merging for stk meshes and improved block naming in Exodu…

### DIFF
--- a/src/Omega_h_stk.hpp
+++ b/src/Omega_h_stk.hpp
@@ -6,10 +6,15 @@ namespace stk { namespace mesh { class BulkData; } }
 
 namespace Omega_h {
 
-namespace stk_mesh {
-void read_from_stk(Mesh* mesh, const stk::mesh::BulkData & stk_mesh);
-void read_from_stk(Mesh* mesh, const stk::mesh::BulkData & stk_mesh, const std::vector<stk::mesh::Entity> & stk_elems);
-}  // namespace stk_mesh
+  namespace stk_mesh {
+    void read_from_stk(Mesh* mesh,
+                       const stk::mesh::BulkData & stk_mesh,
+                       const std::vector<std::pair<std::string,std::set<std::string>>> & merging_block_names);
+    void read_from_stk(Mesh* mesh,
+                       const stk::mesh::BulkData & stk_mesh,
+                       const std::vector<stk::mesh::Entity> & stk_elems,
+                       const std::vector<std::pair<std::string,std::set<std::string>>> & merging_block_names);
+  }  // namespace stk_mesh
 
 }  // namespace Omega_h
 


### PR DESCRIPTION
Block merging enables the combining of disjoint stk mesh blocks into a single named block.  Also, the Exodus write function was modified to retrieve the block name from class_sets rather than utilizing a block_ID naming convention as was done previously.