### PR TITLE
use type alias for Bytes,LOs,GOs,Reals

### DIFF
--- a/src/Omega_h_array.cpp
+++ b/src/Omega_h_array.cpp
@@ -118,44 +118,6 @@ T Write<T>::get(LO i) const {
 #endif
 }
 
-Bytes::Bytes(Write<Byte> write) : Read<Byte>(write) {}
-
-Bytes::Bytes(LO size_in, Byte value, std::string const& name_in)
-    : Read<Byte>(size_in, value, name_in) {}
-
-Bytes::Bytes(std::initializer_list<Byte> l, std::string const& name_in)
-    : Read<Byte>(l, name_in) {}
-
-LOs::LOs(Write<LO> write) : Read<LO>(write) {}
-
-LOs::LOs(LO size_in, LO value, std::string const& name_in)
-    : Read<LO>(size_in, value, name_in) {}
-
-LOs::LOs(LO size_in, LO offset, LO stride, std::string const& name_in)
-    : Read<LO>(size_in, offset, stride, name_in) {}
-
-LOs::LOs(std::initializer_list<LO> l, std::string const& name_in)
-    : Read<LO>(l, name_in) {}
-
-GOs::GOs(Write<GO> write) : Read<GO>(write) {}
-
-GOs::GOs(LO size_in, GO value, std::string const& name_in)
-    : Read<GO>(size_in, value, name_in) {}
-
-GOs::GOs(LO size_in, GO offset, GO stride, std::string const& name_in)
-    : Read<GO>(size_in, offset, stride, name_in) {}
-
-GOs::GOs(std::initializer_list<GO> l, std::string const& name_in)
-    : Read<GO>(l, name_in) {}
-
-Reals::Reals(Write<Real> write) : Read<Real>(write) {}
-
-Reals::Reals(LO size_in, Real value, std::string const& name_in)
-    : Read<Real>(size_in, value, name_in) {}
-
-Reals::Reals(std::initializer_list<Real> l, std::string const& name_in)
-    : Read<Real>(l, name_in) {}
-
 template <typename T>
 Read<T>::Read(Write<T> write) : write_(write) {}
 

--- a/src/Omega_h_array.hpp
+++ b/src/Omega_h_array.hpp
@@ -148,43 +148,11 @@ Read<T> read(Write<T> a) {
   return Read<T>(a);
 }
 
-class Bytes : public Read<Byte> {
- public:
-  OMEGA_H_INLINE Bytes() {}
-  OMEGA_H_INLINE Bytes(Read<Byte> base) : Read<Byte>(base) {}
-  Bytes(Write<Byte> write);
-  Bytes(LO size_in, Byte value, std::string const& name = "");
-  Bytes(std::initializer_list<Byte> l, std::string const& name = "");
-};
+using Bytes = Read<Byte>;
+using LOs = Read<LO>;
+using GOs = Read<GO>;
+using Reals = Read<Real>;
 
-class LOs : public Read<LO> {
- public:
-  OMEGA_H_INLINE LOs() {}
-  OMEGA_H_INLINE LOs(Read<LO> base) : Read<LO>(base) {}
-  LOs(Write<LO> write);
-  LOs(LO size_in, LO value, std::string const& name = "");
-  LOs(LO size_in, LO offset, LO stride, std::string const& name = "");
-  LOs(std::initializer_list<LO> l, std::string const& name = "");
-};
-
-class GOs : public Read<GO> {
- public:
-  OMEGA_H_INLINE GOs() {}
-  OMEGA_H_INLINE GOs(Read<GO> base) : Read<GO>(base) {}
-  GOs(Write<GO> write);
-  GOs(LO size_in, GO value, std::string const& name = "");
-  GOs(LO size_in, GO offset, GO stride, std::string const& name = "");
-  GOs(std::initializer_list<GO> l, std::string const& name = "");
-};
-
-class Reals : public Read<Real> {
- public:
-  OMEGA_H_INLINE Reals() {}
-  OMEGA_H_INLINE Reals(Read<Real> base) : Read<Real>(base) {}
-  Reals(Write<Real> write);
-  Reals(LO size_in, Real value, std::string const& name = "");
-  Reals(std::initializer_list<Real> l, std::string const& name = "");
-};
 
 template <typename T>
 class HostRead {


### PR DESCRIPTION
These type alias' avoid the potential slicing that was happening with
these types and make it easier to write templated overloads that take
these types since they just become Read<T>.