### PR TITLE
Fix few bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,17 +73,7 @@ set(Omega_h_USE_Gmodel_DEFAULT OFF)
 bob_add_dependency(PRIVATE NAME Gmodel TARGETS gmodel)
 
 set(Omega_h_USE_SEACASExodus_DEFAULT OFF)
-set(SEACASExodus_PREFIX_DEFAULT ${Trilinos_PREFIX})
-bob_add_dependency(PUBLIC NAME SEACASExodus
-    TARGETS exodus
-    INCLUDE_DIR_VARS
-      SEACASExodus_INCLUDE_DIRS
-      SEACASExodus_TPL_INCLUDE_DIRS
-    LIBRARY_VARS SEACASExodus_TPL_LIBRARIES)
-if (Omega_h_USE_SEACASExodus)
-  set(Omega_h_USE_HDF5_DEFAULT ON)
-  bob_add_dependency(PUBLIC NAME HDF5 CONFIG)
-endif()
+bob_add_dependency(PUBLIC NAME SEACASExodus TARGETS SEACASExodus::all_libs)
 
 set(Omega_h_USE_pybind11_DEFAULT OFF)
 bob_public_dep(pybind11)

--- a/src/Omega_h_few.hpp
+++ b/src/Omega_h_few.hpp
@@ -38,6 +38,7 @@ class Few {
     OMEGA_H_FEW_AT;
   }
 #undef OMEGA_H_FEW_AT
+  OMEGA_H_INLINE
   Few(std::initializer_list<T> l) {
     Int i = 0;
     for (auto it = l.begin(); it != l.end(); ++it) {
@@ -91,6 +92,7 @@ class Few {
     OMEGA_H_FEW_AT;
   }
 #undef OMEGA_H_FEW_AT
+  OMEGA_H_INLINE
   Few(std::initializer_list<T> l) {
     Int i = 0;
     for (auto it = l.begin(); it != l.end(); ++it) {


### PR DESCRIPTION
This pull request fixes a bug in the few class (missing OMEGA_H_INLINE). When running with Kokkos+Cuda this was causing memory corruption when using the Vector initializer_list constructor since the constructor code did not exist on the device side.

Most likely due to the use through inheritance the compiler was not warning about missing `__host__ __device__` annotations.