### PR TITLE
Use alias for Omega_h_vector.

### DIFF
--- a/src/Omega_h_bbox.hpp
+++ b/src/Omega_h_bbox.hpp
@@ -19,13 +19,11 @@ struct BBox {
   Vector<dim> min;
   Vector<dim> max;
   /* playing the volatile game again (see int128.hpp) */
-  OMEGA_H_INLINE void operator=(BBox<dim> const& rhs) volatile {
+  OMEGA_H_INLINE void operator=(BBox<dim> const& rhs) {
     min = rhs.min;
     max = rhs.max;
   }
   OMEGA_H_INLINE BBox(BBox<dim> const& rhs) : min(rhs.min), max(rhs.max) {}
-  OMEGA_H_INLINE BBox(const volatile BBox<dim>& rhs)
-      : min(rhs.min), max(rhs.max) {}
 };
 
 #else

--- a/src/Omega_h_few.hpp
+++ b/src/Omega_h_few.hpp
@@ -37,6 +37,12 @@ class Few {
   OMEGA_H_INLINE T const volatile& operator[](Int i) const volatile {
     OMEGA_H_FEW_AT;
   }
+  OMEGA_H_INLINE T& operator()(Int i) { OMEGA_H_FEW_AT; }
+  OMEGA_H_INLINE T const& operator()(Int i) const { OMEGA_H_FEW_AT; }
+  OMEGA_H_INLINE T volatile& operator()(Int i) volatile { OMEGA_H_FEW_AT; }
+  OMEGA_H_INLINE T const volatile& operator()(Int i) const volatile {
+    OMEGA_H_FEW_AT;
+  }
 #undef OMEGA_H_FEW_AT
   Few(std::initializer_list<T> l) {
     Int i = 0;
@@ -88,6 +94,10 @@ class Few {
 #endif
   OMEGA_H_INLINE T& operator[](Int i) OMEGA_H_NOEXCEPT { OMEGA_H_FEW_AT; }
   OMEGA_H_INLINE T const& operator[](Int i) const OMEGA_H_NOEXCEPT {
+    OMEGA_H_FEW_AT;
+  }
+  OMEGA_H_INLINE T& operator()(Int i) OMEGA_H_NOEXCEPT { OMEGA_H_FEW_AT; }
+  OMEGA_H_INLINE T const& operator()(Int i) const OMEGA_H_NOEXCEPT {
     OMEGA_H_FEW_AT;
   }
 #undef OMEGA_H_FEW_AT

--- a/src/Omega_h_few.hpp
+++ b/src/Omega_h_few.hpp
@@ -20,8 +20,6 @@ class Few {
   using value_type = T;
   OMEGA_H_INLINE T* data() { return array_; }
   OMEGA_H_INLINE T const* data() const { return array_; }
-  OMEGA_H_INLINE T volatile* data() volatile { return array_; }
-  OMEGA_H_INLINE T const volatile* data() const volatile { return array_; }
   OMEGA_H_INLINE constexpr Int size() const { return n; }
 #ifdef OMEGA_H_CHECK_BOUNDS
 #define OMEGA_H_FEW_AT                                                         \
@@ -33,16 +31,8 @@ class Few {
 #endif
   OMEGA_H_INLINE T& operator[](Int i) { OMEGA_H_FEW_AT; }
   OMEGA_H_INLINE T const& operator[](Int i) const { OMEGA_H_FEW_AT; }
-  OMEGA_H_INLINE T volatile& operator[](Int i) volatile { OMEGA_H_FEW_AT; }
-  OMEGA_H_INLINE T const volatile& operator[](Int i) const volatile {
-    OMEGA_H_FEW_AT;
-  }
   OMEGA_H_INLINE T& operator()(Int i) { OMEGA_H_FEW_AT; }
   OMEGA_H_INLINE T const& operator()(Int i) const { OMEGA_H_FEW_AT; }
-  OMEGA_H_INLINE T volatile& operator()(Int i) volatile { OMEGA_H_FEW_AT; }
-  OMEGA_H_INLINE T const volatile& operator()(Int i) const volatile {
-    OMEGA_H_FEW_AT;
-  }
 #undef OMEGA_H_FEW_AT
   Few(std::initializer_list<T> l) {
     Int i = 0;
@@ -52,19 +42,10 @@ class Few {
   }
   OMEGA_H_INLINE Few() {}
   OMEGA_H_INLINE ~Few() {}
-  OMEGA_H_INLINE void operator=(Few<T, n> const& rhs) volatile {
-    for (Int i = 0; i < n; ++i) array_[i] = rhs[i];
-  }
   OMEGA_H_INLINE void operator=(Few<T, n> const& rhs) {
     for (Int i = 0; i < n; ++i) array_[i] = rhs[i];
   }
-  OMEGA_H_INLINE void operator=(Few<T, n> const volatile& rhs) {
-    for (Int i = 0; i < n; ++i) array_[i] = rhs[i];
-  }
   OMEGA_H_INLINE Few(Few<T, n> const& rhs) {
-    for (Int i = 0; i < n; ++i) new (array_ + i) T(rhs[i]);
-  }
-  OMEGA_H_INLINE Few(Few<T, n> const volatile& rhs) {
     for (Int i = 0; i < n; ++i) new (array_ + i) T(rhs[i]);
   }
   OMEGA_H_INLINE const T* begin() const OMEGA_H_NOEXCEPT { return array_; }

--- a/src/Omega_h_matrix.hpp
+++ b/src/Omega_h_matrix.hpp
@@ -19,22 +19,11 @@ class Matrix : public Few<Vector<m>, n> {
    */
   inline Matrix(std::initializer_list<Vector<m>> l) : Few<Vector<m>, n>(l) {}
   inline Matrix(std::initializer_list<Real> l);
-  OMEGA_H_INLINE void operator=(Matrix<m, n> const& rhs) volatile {
-    Few<Vector<m>, n>::operator=(rhs);
-  }
   OMEGA_H_INLINE Matrix(Matrix<m, n> const& rhs) : Few<Vector<m>, n>(rhs) {}
-  OMEGA_H_INLINE Matrix(const volatile Matrix<m, n>& rhs)
-      : Few<Vector<m>, n>(rhs) {}
   OMEGA_H_INLINE Real& operator()(Int i, Int j) {
     return Few<Vector<m>, n>::operator[](j)[i];
   }
   OMEGA_H_INLINE Real const& operator()(Int i, Int j) const {
-    return Few<Vector<m>, n>::operator[](j)[i];
-  }
-  OMEGA_H_INLINE Real volatile& operator()(Int i, Int j) volatile {
-    return Few<Vector<m>, n>::operator[](j)[i];
-  }
-  OMEGA_H_INLINE Real const volatile& operator()(Int i, Int j) const volatile {
     return Few<Vector<m>, n>::operator[](j)[i];
   }
 };

--- a/src/Omega_h_vector.hpp
+++ b/src/Omega_h_vector.hpp
@@ -6,53 +6,9 @@
 
 namespace Omega_h {
 
-#ifdef OMEGA_H_USE_KOKKOS
 
 template <Int n>
-class Vector : public Few<Real, n> {
- public:
-  OMEGA_H_INLINE Vector() {}
-  inline Vector(std::initializer_list<Real> l) : Few<Real, n>(l) {}
-  OMEGA_H_INLINE void operator=(Vector<n> const& rhs) volatile {
-    Few<Real, n>::operator=(rhs);
-  }
-  OMEGA_H_INLINE void operator=(Vector<n> const& rhs) {
-    Few<Real, n>::operator=(rhs);
-  }
-  OMEGA_H_INLINE Vector(Vector<n> const& rhs) : Few<Real, n>(rhs) {}
-  OMEGA_H_INLINE Vector(const volatile Vector<n>& rhs) : Few<Real, n>(rhs) {}
-#define OMEGA_H_VECTOR_AT return Few<Real, n>::operator[](i)
-  OMEGA_H_INLINE Real& operator()(Int i) { OMEGA_H_VECTOR_AT; }
-  OMEGA_H_INLINE Real const& operator()(Int i) const { OMEGA_H_VECTOR_AT; }
-  OMEGA_H_INLINE Real volatile& operator()(Int i) volatile {
-    OMEGA_H_VECTOR_AT;
-  }
-  OMEGA_H_INLINE Real const volatile& operator()(Int i) const volatile {
-    OMEGA_H_VECTOR_AT;
-  }
-#undef OMEGA_H_VECTOR_AT
-};
-
-#else
-
-template <Int n>
-class Vector : public Few<Real, n> {
- public:
-  inline Vector() = default;
-  inline Vector(std::initializer_list<Real> l) : Few<Real, n>(l) {}
-  inline Vector& operator=(Vector const&) = default;
-  inline Vector& operator=(Vector&&) = default;
-  inline Vector(Vector const&) = default;
-  inline Vector(Vector&&) = default;
-#define OMEGA_H_VECTOR_AT return Few<Real, n>::operator[](i)
-  OMEGA_H_INLINE Real& operator()(Int i) OMEGA_H_NOEXCEPT { OMEGA_H_VECTOR_AT; }
-  OMEGA_H_INLINE Real const& operator()(Int i) const OMEGA_H_NOEXCEPT {
-    OMEGA_H_VECTOR_AT;
-  }
-#undef OMEGA_H_VECTOR_AT
-};
-
-#endif
+using Vector = Few<Real,n>;
 
 template <Int n>
 OMEGA_H_INLINE Real* scalar_ptr(Vector<n>& v) {


### PR DESCRIPTION
This pull request replaces the `Vector` class with an alias for `Few`. The current implementation of `Vector` is essentially just an alias with the addition of `operator()`.