### PR TITLE
Add mising OMEGA_H_INLINE for gpu compute

### DIFF
--- a/src/Omega_h_few.hpp
+++ b/src/Omega_h_few.hpp
@@ -38,6 +38,7 @@ class Few {
     OMEGA_H_FEW_AT;
   }
 #undef OMEGA_H_FEW_AT
+  OMEGA_H_INLINE
   Few(std::initializer_list<T> l) {
     Int i = 0;
     for (auto it = l.begin(); it != l.end(); ++it) {
@@ -91,6 +92,7 @@ class Few {
     OMEGA_H_FEW_AT;
   }
 #undef OMEGA_H_FEW_AT
+  OMEGA_H_INLINE
   Few(std::initializer_list<T> l) {
     Int i = 0;
     for (auto it = l.begin(); it != l.end(); ++it) {


### PR DESCRIPTION
This pull request fixes a bug in the few class (missing OMEGA_H_INLINE). When running with Kokkos+Cuda this was causing memory corruption when using the Vector initializer_list constructor since the constructor code did not exist on the device side.

Most likely due to the use through inheritance the compiler was not warning about missing __host__ __device__ annotations.