### PR TITLE
needed for cuda12 for thrust::device

### DIFF
--- a/src/Omega_h_reduce.hpp
+++ b/src/Omega_h_reduce.hpp
@@ -15,6 +15,7 @@
 #endif
 #include <thrust/functional.h>
 #include <thrust/transform_reduce.h>
+#include <thrust/execution_policy.h>
 #include <cuda_runtime_api.h>
 #ifdef __GNUC__
 #pragma GCC diagnostic pop


### PR DESCRIPTION
See https://github.com/SCOREC/omega_h/issues/49.  The error was hit with a spack build using cuda12 here: https://github.com/spack/spack/issues/39535.